### PR TITLE
fix: resolve audit finding AST-101 (and part of AST-302)

### DIFF
--- a/onchain/src/validators/asteria.ak
+++ b/onchain/src/validators/asteria.ak
@@ -45,27 +45,38 @@ validator asteria(
             outputs,
             fn(output) { output.address == asteria_input.output.address },
           )
-        expect InlineDatum(asteria_output_datum) = asteria_output.datum
-        expect asteria_output_datum: AsteriaDatum = asteria_output_datum
+        expect Output {
+          address: Address(_, None),
+          value: asteria_value,
+          datum: InlineDatum(asteria_datum),
+          reference_script: None,
+        } = asteria_output
+
+        // check for correct Asteria output datum
+        expect asteria_datum: AsteriaDatum = asteria_datum
+        let asteria_must_have_correct_datum =
+          AsteriaDatum {
+            ship_counter: ship_counter + 1,
+            shipyard_policy: shipyard_policy,
+          } == asteria_datum
 
         // check for correct Asteria output value
         let must_hold_admin_token =
           quantity_of(
-            asteria_output.value,
+            asteria_value,
             admin_token.policy,
             admin_token.name,
           ) > 0
         let must_add_fee =
-          asteria_output.value == (
+          asteria_value == (
             asteria_input.output.value
               |> add(ada_policy_id, ada_asset_name, ship_mint_lovelace_fee)
           )
-
-        // check for correct Asteria output datum
-        let must_increment_counter =
-          asteria_output_datum.ship_counter == ship_counter + 1
-        let must_preserve_shipyard_policy =
-          asteria_output_datum.shipyard_policy == shipyard_policy
+        let asteria_must_have_correct_value =
+          and {
+            must_add_fee?,
+            must_hold_admin_token?,
+          }
 
         // check for correct creation of ship UTxO
         expect [ship_output] =
@@ -123,10 +134,8 @@ validator asteria(
         let must_mint_expected_value = mint == expected_minted_value
 
         and {
-          must_add_fee?,
-          must_hold_admin_token?,
-          must_increment_counter?,
-          must_preserve_shipyard_policy?,
+          asteria_must_have_correct_value?,
+          asteria_must_have_correct_datum?,
           ship_must_have_correct_datum?,
           ship_must_have_correct_value?,
           must_mint_expected_value?,

--- a/onchain/src/validators/asteria.ak
+++ b/onchain/src/validators/asteria.ak
@@ -99,7 +99,7 @@ validator asteria(
           )
         let must_have_latest_time = {
           expect Finite(tx_latest_time) = validity_range.upper_bound.bound_type
-          last_move_latest_time == tx_latest_time
+          last_move_latest_time >= tx_latest_time
         }
         let ship_must_have_correct_datum = and {
             must_respect_min_distance?,

--- a/onchain/src/validators/asteria.ak
+++ b/onchain/src/validators/asteria.ak
@@ -46,7 +46,7 @@ validator asteria(
             fn(output) { output.address == asteria_input.output.address },
           )
         expect Output {
-          address: Address(_, None),
+          address: _,
           value: asteria_value,
           datum: InlineDatum(asteria_datum),
           reference_script: None,
@@ -55,25 +55,17 @@ validator asteria(
         // check for correct Asteria output datum
         expect asteria_datum: AsteriaDatum = asteria_datum
         let asteria_must_have_correct_datum =
-          AsteriaDatum {
-            ship_counter: ship_counter + 1,
-            shipyard_policy: shipyard_policy,
-          } == asteria_datum
+          AsteriaDatum { ship_counter: ship_counter + 1, shipyard_policy } == asteria_datum
 
         // check for correct Asteria output value
         let must_hold_admin_token =
-          quantity_of(
-            asteria_value,
-            admin_token.policy,
-            admin_token.name,
-          ) > 0
+          quantity_of(asteria_value, admin_token.policy, admin_token.name) > 0
         let must_add_fee =
           asteria_value == (
             asteria_input.output.value
               |> add(ada_policy_id, ada_asset_name, ship_mint_lovelace_fee)
           )
-        let asteria_must_have_correct_value =
-          and {
+        let asteria_must_have_correct_value = and {
             must_add_fee?,
             must_hold_admin_token?,
           }

--- a/onchain/src/validators/asteria.ak
+++ b/onchain/src/validators/asteria.ak
@@ -1,19 +1,22 @@
-use aiken/primitive/bytearray
-use aiken/primitive/string
 use aiken/collection/dict
 use aiken/collection/list
 use aiken/crypto.{ScriptHash}
 use aiken/interval.{Finite}
 use aiken/math/rational.{compare_with, from_int}
 use aiken/option
+use aiken/primitive/bytearray
+use aiken/primitive/string
 use asteria/types.{
-  ShipDatum, AddNewShip, AssetClass, AsteriaDatum, AsteriaRedeemer, ConsumeAsteria, Mine,
+  AddNewShip, AssetClass, AsteriaDatum, AsteriaRedeemer, ConsumeAsteria, Mine,
+  ShipDatum,
 }
 use asteria/utils
 use cardano/assets.{
   ada_asset_name, ada_policy_id, add, lovelace_of, quantity_of, tokens,
 }
-use cardano/transaction.{InlineDatum, Output, OutputReference, Transaction, find_input}
+use cardano/transaction.{
+  InlineDatum, Output, OutputReference, Transaction, find_input,
+}
 
 validator asteria(
   pellet_address: ScriptHash,
@@ -29,7 +32,7 @@ validator asteria(
     utxo: OutputReference,
     self: Transaction,
   ) {
-    let Transaction { inputs, outputs, validity_range, .. } = self
+    let Transaction { inputs, outputs, mint, validity_range, .. } = self
     expect Some(datum) = datum
     let AsteriaDatum { ship_counter, shipyard_policy } = datum
     expect Some(asteria_input) = find_input(inputs, utxo)
@@ -64,23 +67,12 @@ validator asteria(
         expect [ship_output] =
           transaction.find_script_outputs(outputs, shipyard_policy)
         expect Output {
-              address: _ship_address,  // XXX: must check??
-              value: ship_value,
-              datum: InlineDatum(ship_datum),
-              reference_script: None,
-            } = ship_output
-
-        let expected_ship_token_name = bytearray.concat(
-          "SHIP",
-          bytearray.from_string(string.from_int(ship_counter)),
-        )
-
-        // check for correct creation of ship UTxO: check value
-        let expected_ship_value =
-          assets.from_asset(shipyard_policy, expected_ship_token_name, 1)
-          |> assets.add(pellet_address, "FUEL", initial_fuel)
-        let must_have_correct_value =
-          assets.match(ship_value, expected_ship_value, >=)
+          address: _ship_address,
+          // XXX: must check??
+          value: ship_value,
+          datum: InlineDatum(ship_datum),
+          reference_script: None,
+        } = ship_output
 
         // check for correct creation of ship UTxO: check datum
         expect ShipDatum {
@@ -93,28 +85,48 @@ validator asteria(
         let must_respect_min_distance =
           utils.distance(pos_x, pos_y) >= min_asteria_distance
         let must_have_ship_name =
-          ship_token_name == expected_ship_token_name
+          ship_token_name == bytearray.concat(
+            "SHIP",
+            bytearray.from_string(string.from_int(ship_counter)),
+          )
         let must_have_pilot_name =
-          pilot_token_name ==
-            bytearray.concat(
-              "PILOT",
-              bytearray.from_string(string.from_int(ship_counter)),
-            )
+          pilot_token_name == bytearray.concat(
+            "PILOT",
+            bytearray.from_string(string.from_int(ship_counter)),
+          )
         let must_have_latest_time = {
           expect Finite(tx_latest_time) = validity_range.upper_bound.bound_type
           last_move_latest_time == tx_latest_time
         }
+        let ship_must_have_correct_datum = and {
+            must_respect_min_distance?,
+            must_have_ship_name?,
+            must_have_pilot_name?,
+            must_have_latest_time?,
+          }
+
+        // check for correct creation of ship UTxO: check value
+        let expected_ship_value =
+          assets.from_asset(shipyard_policy, ship_token_name, 1)
+            |> assets.add(pellet_address, "FUEL", initial_fuel)
+        let ship_must_have_correct_value =
+          assets.match(ship_value, expected_ship_value, >=)
+
+        // check minting
+        let expected_minted_value =
+          assets.from_asset(shipyard_policy, ship_token_name, 1)
+            |> assets.add(shipyard_policy, pilot_token_name, 1)
+            |> assets.add(pellet_address, "FUEL", initial_fuel)
+        let must_mint_expected_value = mint == expected_minted_value
 
         and {
           must_add_fee?,
           must_hold_admin_token?,
           must_increment_counter?,
           must_preserve_shipyard_policy?,
-          must_have_correct_value?,
-          must_respect_min_distance?,
-          must_have_ship_name?,
-          must_have_pilot_name?,
-          must_have_latest_time?,
+          ship_must_have_correct_datum?,
+          ship_must_have_correct_value?,
+          must_mint_expected_value?,
         }
       }
 

--- a/onchain/src/validators/asteria.ak
+++ b/onchain/src/validators/asteria.ak
@@ -11,6 +11,7 @@ use asteria/types.{
   ShipDatum,
 }
 use asteria/utils
+use cardano/address.{Address}
 use cardano/assets.{
   ada_asset_name, ada_policy_id, add, lovelace_of, quantity_of, tokens,
 }
@@ -47,6 +48,7 @@ validator asteria(
         expect InlineDatum(asteria_output_datum) = asteria_output.datum
         expect asteria_output_datum: AsteriaDatum = asteria_output_datum
 
+        // check for correct Asteria output value
         let must_hold_admin_token =
           quantity_of(
             asteria_output.value,
@@ -58,6 +60,8 @@ validator asteria(
             asteria_input.output.value
               |> add(ada_policy_id, ada_asset_name, ship_mint_lovelace_fee)
           )
+
+        // check for correct Asteria output datum
         let must_increment_counter =
           asteria_output_datum.ship_counter == ship_counter + 1
         let must_preserve_shipyard_policy =
@@ -67,8 +71,7 @@ validator asteria(
         expect [ship_output] =
           transaction.find_script_outputs(outputs, shipyard_policy)
         expect Output {
-          address: _ship_address,
-          // XXX: must check??
+          address: Address(_, None),
           value: ship_value,
           datum: InlineDatum(ship_datum),
           reference_script: None,

--- a/onchain/src/validators/asteria.ak
+++ b/onchain/src/validators/asteria.ak
@@ -1,20 +1,27 @@
+use aiken/primitive/bytearray
+use aiken/primitive/string
 use aiken/collection/dict
 use aiken/collection/list
+use aiken/crypto.{ScriptHash}
+use aiken/interval.{Finite}
 use aiken/math/rational.{compare_with, from_int}
 use aiken/option
 use asteria/types.{
-  AddNewShip, AssetClass, AsteriaDatum, AsteriaRedeemer, ConsumeAsteria, Mine,
+  ShipDatum, AddNewShip, AssetClass, AsteriaDatum, AsteriaRedeemer, ConsumeAsteria, Mine,
 }
 use asteria/utils
 use cardano/assets.{
   ada_asset_name, ada_policy_id, add, lovelace_of, quantity_of, tokens,
 }
-use cardano/transaction.{InlineDatum, OutputReference, Transaction, find_input}
+use cardano/transaction.{InlineDatum, Output, OutputReference, Transaction, find_input}
 
 validator asteria(
+  pellet_address: ScriptHash,
   admin_token: AssetClass,
   ship_mint_lovelace_fee: Int,
   max_asteria_mining: Int,
+  min_asteria_distance: Int,
+  initial_fuel: Int,
 ) {
   spend(
     datum: Option<AsteriaDatum>,
@@ -22,7 +29,7 @@ validator asteria(
     utxo: OutputReference,
     self: Transaction,
   ) {
-    let Transaction { inputs, outputs, .. } = self
+    let Transaction { inputs, outputs, validity_range, .. } = self
     expect Some(datum) = datum
     let AsteriaDatum { ship_counter, shipyard_policy } = datum
     expect Some(asteria_input) = find_input(inputs, utxo)
@@ -53,11 +60,61 @@ validator asteria(
         let must_preserve_shipyard_policy =
           asteria_output_datum.shipyard_policy == shipyard_policy
 
+        // check for correct creation of ship UTxO
+        expect [ship_output] =
+          transaction.find_script_outputs(outputs, shipyard_policy)
+        expect Output {
+              address: _ship_address,  // XXX: must check??
+              value: ship_value,
+              datum: InlineDatum(ship_datum),
+              reference_script: None,
+            } = ship_output
+
+        let expected_ship_token_name = bytearray.concat(
+          "SHIP",
+          bytearray.from_string(string.from_int(ship_counter)),
+        )
+
+        // check for correct creation of ship UTxO: check value
+        let expected_ship_value =
+          assets.from_asset(shipyard_policy, expected_ship_token_name, 1)
+          |> assets.add(pellet_address, "FUEL", initial_fuel)
+        let must_have_correct_value =
+          assets.match(ship_value, expected_ship_value, >=)
+
+        // check for correct creation of ship UTxO: check datum
+        expect ShipDatum {
+          pos_x,
+          pos_y,
+          ship_token_name,
+          pilot_token_name,
+          last_move_latest_time,
+        } = ship_datum
+        let must_respect_min_distance =
+          utils.distance(pos_x, pos_y) >= min_asteria_distance
+        let must_have_ship_name =
+          ship_token_name == expected_ship_token_name
+        let must_have_pilot_name =
+          pilot_token_name ==
+            bytearray.concat(
+              "PILOT",
+              bytearray.from_string(string.from_int(ship_counter)),
+            )
+        let must_have_latest_time = {
+          expect Finite(tx_latest_time) = validity_range.upper_bound.bound_type
+          last_move_latest_time == tx_latest_time
+        }
+
         and {
           must_add_fee?,
           must_hold_admin_token?,
           must_increment_counter?,
           must_preserve_shipyard_policy?,
+          must_have_correct_value?,
+          must_respect_min_distance?,
+          must_have_ship_name?,
+          must_have_pilot_name?,
+          must_have_latest_time?,
         }
       }
 

--- a/onchain/src/validators/pellet.ak
+++ b/onchain/src/validators/pellet.ak
@@ -1,15 +1,16 @@
 use aiken/collection/dict
 use aiken/collection/list.{filter}
+use aiken/collection/pairs
 use aiken/option
 use asteria/types.{
-  AssetClass, BurnFuel, ConsumePellet, FuelRedeemer, MintFuel, PelletDatum,
-  PelletRedeemer, Provide,
+  AddNewShip, AssetClass, BurnFuel, ConsumePellet, FuelRedeemer, MintFuel,
+  PelletDatum, PelletRedeemer, Provide,
 }
 use asteria/utils
-use cardano/address.{Script}
+use cardano/address.{Script, VerificationKey}
 use cardano/assets.{PolicyId, quantity_of, tokens}
 use cardano/transaction.{
-  InlineDatum, Output, OutputReference, Transaction, find_input,
+  InlineDatum, Output, OutputReference, Spend, Transaction, find_input,
 }
 
 validator pellet(admin_token: AssetClass) {
@@ -89,13 +90,21 @@ validator pellet(admin_token: AssetClass) {
   }
 
   mint(redeemer: FuelRedeemer, fuel_policy: PolicyId, self: Transaction) {
-    let Transaction { inputs, mint, .. } = self
-    let minted_value = mint
+    let Transaction { inputs, mint, redeemers, .. } = self
+
+    // only "FUEL" can be minted, extract amount
+    expect [Pair("FUEL", amount)] =
+      mint
+        |> tokens(fuel_policy)
+        |> dict.to_pairs()
 
     when redeemer is {
       MintFuel -> {
-        // check that there is an input with the admin token
-        let admin_token_input =
+        // fuel can be minted by admin when creating a Pellet
+        // or by a user when creating a ship (Asteria is spent)
+
+        // there is an input with the admin token
+        expect Some(admin_token_input) =
           list.find(
             inputs,
             fn(input) {
@@ -107,17 +116,30 @@ validator pellet(admin_token: AssetClass) {
             },
           )
 
-        let must_mint_fuel_tokens =
-          quantity_of(minted_value, fuel_policy, "FUEL") > 0
+        // admin token is in a wallet input
+        let must_be_admin =
+          not(utils.is_script_address(admin_token_input.output.address))
 
-        option.is_some(admin_token_input)? && must_mint_fuel_tokens?
-      }
-      BurnFuel -> {
-        let must_burn_fuel_tokens =
-          quantity_of(minted_value, fuel_policy, "FUEL") < 0
+        // admin token is in an Asteria input with redeemer AddNewShip
+        let must_be_add_new_ship =
+          when admin_token_input.output.address.payment_credential is {
+            VerificationKey(_) -> False
+            Script(addr_payment) -> {
+              // it is a script and not a pellet, then it is Asteria
+              let must_be_asteria = addr_payment != fuel_policy
 
-        must_burn_fuel_tokens?
+              let asteria_purpose = Spend(admin_token_input.output_reference)
+              let asteria_redeemer: Data = AddNewShip
+              let must_be_correct_purpose =
+                pairs.get_all(redeemers, asteria_purpose) == [asteria_redeemer]
+
+              must_be_asteria? && must_be_correct_purpose?
+            }
+          }
+
+        amount > 0 && ( must_be_admin? || must_be_add_new_ship? )
       }
+      BurnFuel -> amount < 0
     }
   }
 

--- a/onchain/src/validators/spacetime.ak
+++ b/onchain/src/validators/spacetime.ak
@@ -23,8 +23,6 @@ validator spacetime(
   max_speed: Speed,
   max_ship_fuel: Int,
   fuel_per_step: Int,
-  _initial_fuel: Int,  // TODO: remove
-  _min_asteria_distance: Int,  // TODO: remove
 ) {
   // SPACETIME VALIDATOR:
   spend(

--- a/onchain/src/validators/spacetime.ak
+++ b/onchain/src/validators/spacetime.ak
@@ -26,7 +26,7 @@ validator spacetime(
   max_ship_fuel: Int,
   fuel_per_step: Int,
   initial_fuel: Int,
-  min_asteria_distance: Int,
+  _min_asteria_distance: Int,  // TODO: remove
 ) {
   // SPACETIME VALIDATOR:
   spend(
@@ -279,7 +279,7 @@ validator spacetime(
 
   // SHIPYARD POLICY:
   mint(redeemer: ShipyardRedeemer, shipyard_policy: PolicyId, self: Transaction) {
-    let Transaction { inputs, outputs, mint, validity_range, .. } = self
+    let Transaction { inputs, mint, .. } = self
     let minted_value = mint
 
     let fuel_policy = pellet_validator_address
@@ -306,12 +306,6 @@ validator spacetime(
         expect InlineDatum(asteria_datum) = asteria_input.output.datum
         expect asteria_datum: AsteriaDatum = asteria_datum
 
-        expect [ship_state] =
-          transaction.find_script_outputs(outputs, shipyard_policy)
-        expect InlineDatum(ship_datum) = ship_state.datum
-        expect ship_datum: ShipDatum = ship_datum
-        expect Finite(tx_latest_time) = validity_range.upper_bound.bound_type
-
         let ship_token_name =
           bytearray.concat(
             "SHIP",
@@ -328,29 +322,10 @@ validator spacetime(
             |> add(fuel_policy, "FUEL", initial_fuel)
 
         let must_mint_expected_value = minted_value == expected_minted_value
-        let must_respect_min_distance =
-          utils.distance(ship_datum.pos_x, ship_datum.pos_y) >= min_asteria_distance
-        let must_have_ship_name = ship_datum.ship_token_name == ship_token_name
-        let must_have_pilot_name =
-          ship_datum.pilot_token_name == pilot_token_name
-        let must_have_latest_time =
-          ship_datum.last_move_latest_time == tx_latest_time
-        let must_hold_ship_token =
-          quantity_of(ship_state.value, shipyard_policy, ship_token_name) == 1
-        let must_hold_initial_fuel =
-          quantity_of(ship_state.value, fuel_policy, "FUEL") == initial_fuel
-        let must_hold_3_assets = list.length(ship_state.value |> flatten) == 3
 
         and {
           must_be_valid_asteria?,
           must_mint_expected_value?,
-          must_respect_min_distance?,
-          must_have_ship_name?,
-          must_have_pilot_name?,
-          must_have_latest_time?,
-          must_hold_ship_token?,
-          must_hold_initial_fuel?,
-          must_hold_3_assets?,
         }
       }
 

--- a/onchain/src/validators/spacetime.ak
+++ b/onchain/src/validators/spacetime.ak
@@ -4,19 +4,17 @@ use aiken/collection/pairs
 use aiken/interval.{Finite}
 use aiken/math/rational
 use aiken/option
-use aiken/primitive/bytearray
-use aiken/primitive/string
 use asteria/types.{
-  AssetClass, AsteriaDatum, BurnShip, GatherFuel, MineAsteria, MintShip,
-  MoveShip, PelletDatum, Quit, ScriptAddress, ShipDatum, ShipRedeemer,
-  ShipyardRedeemer, Speed, Provide,
+  AddNewShip, AssetClass, BurnShip, GatherFuel, MineAsteria, MintShip, MoveShip,
+  PelletDatum, Provide, Quit, ScriptAddress, ShipDatum, ShipRedeemer,
+  ShipyardRedeemer, Speed,
 }
 use asteria/utils
 use cardano/address.{Address, Script, VerificationKey}
-use cardano/assets.{
-  PolicyId, add, flatten, from_asset, quantity_of, tokens, zero,
+use cardano/assets.{PolicyId, flatten, quantity_of, tokens, zero}
+use cardano/transaction.{
+  InlineDatum, OutputReference, Spend, Transaction, find_input,
 }
-use cardano/transaction.{InlineDatum, OutputReference, Transaction, Spend, find_input}
 
 validator spacetime(
   pellet_validator_address: ScriptAddress,
@@ -25,7 +23,7 @@ validator spacetime(
   max_speed: Speed,
   max_ship_fuel: Int,
   fuel_per_step: Int,
-  initial_fuel: Int,
+  _initial_fuel: Int,  // TODO: remove
   _min_asteria_distance: Int,  // TODO: remove
 ) {
   // SPACETIME VALIDATOR:
@@ -35,7 +33,8 @@ validator spacetime(
     utxo: OutputReference,
     self: Transaction,
   ) {
-    let Transaction { inputs, outputs, mint, validity_range, redeemers, .. } = self
+    let Transaction { inputs, outputs, mint, validity_range, redeemers, .. } =
+      self
     expect Some(datum) = datum
     let ShipDatum {
       pos_x,
@@ -279,10 +278,8 @@ validator spacetime(
 
   // SHIPYARD POLICY:
   mint(redeemer: ShipyardRedeemer, shipyard_policy: PolicyId, self: Transaction) {
-    let Transaction { inputs, mint, .. } = self
+    let Transaction { inputs, mint, redeemers, .. } = self
     let minted_value = mint
-
-    let fuel_policy = pellet_validator_address
 
     when redeemer is {
       MintShip -> {
@@ -303,29 +300,15 @@ validator spacetime(
             admin_token.policy,
             admin_token.name,
           ) > 0
-        expect InlineDatum(asteria_datum) = asteria_input.output.datum
-        expect asteria_datum: AsteriaDatum = asteria_datum
 
-        let ship_token_name =
-          bytearray.concat(
-            "SHIP",
-            bytearray.from_string(string.from_int(asteria_datum.ship_counter)),
-          )
-        let pilot_token_name =
-          bytearray.concat(
-            "PILOT",
-            bytearray.from_string(string.from_int(asteria_datum.ship_counter)),
-          )
-        let expected_minted_value =
-          from_asset(shipyard_policy, ship_token_name, 1)
-            |> add(shipyard_policy, pilot_token_name, 1)
-            |> add(fuel_policy, "FUEL", initial_fuel)
-
-        let must_mint_expected_value = minted_value == expected_minted_value
+        let asteria_purpose = Spend(asteria_input.output_reference)
+        let asteria_redeemer: Data = AddNewShip
+        let must_be_correct_purpose =
+          pairs.get_all(redeemers, asteria_purpose) == [asteria_redeemer]
 
         and {
           must_be_valid_asteria?,
-          must_mint_expected_value?,
+          must_be_correct_purpose?,
         }
       }
 

--- a/onchain/src/validators/tests/asteria/add_new_ship.ak
+++ b/onchain/src/validators/tests/asteria/add_new_ship.ak
@@ -127,11 +127,16 @@ fn addNewShip(options: AddTestOptions) -> Bool {
       current_treasury_amount: None,
       treasury_donation: None,
     }
+  let min_distance = 10
+  let initial_fuel = 480
   let result =
     asteria.asteria.spend(
+      mock.pellet_credential,
       admin_token,
       ship_mint_lovelace_fee,
       max_asteria_mining,
+      min_distance,
+      initial_fuel,
       Some(asteria_datum),
       redeemer,
       OutputReference { transaction_id: mock.transaction_id_1, output_index: 0 },

--- a/onchain/src/validators/tests/asteria/add_new_ship.ak
+++ b/onchain/src/validators/tests/asteria/add_new_ship.ak
@@ -2,9 +2,11 @@ use aiken/collection/dict
 use aiken/interval.{Finite, Interval, IntervalBound}
 use asteria
 use asteria/test_mock as mock
-use asteria/types.{AddNewShip, AssetClass, AsteriaDatum}
+use asteria/types.{AddNewShip, AssetClass, AsteriaDatum, ShipDatum}
 use cardano/address.{Address, Script}
-use cardano/assets.{ada_asset_name, ada_policy_id, add, from_lovelace, zero}
+use cardano/assets.{
+  AssetName, ada_asset_name, ada_policy_id, add, from_asset, from_lovelace,
+}
 use cardano/transaction.{
   InlineDatum, Input, Output, OutputReference, Spend, Transaction,
 }
@@ -18,6 +20,24 @@ type AddTestOptions {
   include_admin_token: Bool,
   update_counter: Bool,
   preserve_policy: Bool,
+  // fields from mint_ship:MintTestOptions
+  initial_x: Int,
+  initial_y: Int,
+  fuel_paid: Int,
+  latest_time: Int,
+  ship_counter: Int,
+  initial_fuel: Int,
+  ship_tokens_paid: Int,
+  extra_token_amount: Int,
+  fuel_minted_amount: Int,
+  ship_token_minted_amount: Int,
+  pilot_token_minted_amount: Int,
+  ship_token_name: AssetName,
+  datum_ship_name: AssetName,
+  pilot_token_name: AssetName,
+  datum_pilot_name: AssetName,
+  includes_ship_output: Bool,
+  uses_correct_latest_time: Bool,
 }
 
 fn default_add_options() {
@@ -26,10 +46,29 @@ fn default_add_options() {
     include_admin_token: True,
     update_counter: True,
     preserve_policy: True,
+    // fields from mint_ship:MintTestOptions
+    initial_x: 10,
+    initial_y: 10,
+    fuel_paid: 40,
+    latest_time: 10_000,
+    ship_counter: 7,
+    initial_fuel: 40,
+    ship_tokens_paid: 1,
+    extra_token_amount: 0,
+    fuel_minted_amount: 40,
+    ship_token_minted_amount: 1,
+    pilot_token_minted_amount: 1,
+    ship_token_name: "SHIP7",
+    datum_ship_name: "SHIP7",
+    pilot_token_name: "PILOT7",
+    datum_pilot_name: "PILOT7",
+    includes_ship_output: True,
+    uses_correct_latest_time: True,
   }
 }
 
-fn addNewShip(options: AddTestOptions) -> Bool {
+fn add_new_ship(options: AddTestOptions) -> Bool {
+  let shipyard_policy = mock.shipyard_policy
   let ship_mint_lovelace_fee = 2_000
   let max_asteria_mining = 40
   let ship_counter = 7
@@ -48,8 +87,7 @@ fn addNewShip(options: AddTestOptions) -> Bool {
     } else {
       from_lovelace(10_000_000)
     }
-  let asteria_datum =
-    AsteriaDatum { ship_counter, shipyard_policy: mock.shipyard_policy }
+  let asteria_datum = AsteriaDatum { ship_counter, shipyard_policy }
   let asteria_in = {
     let output =
       Output {
@@ -82,19 +120,62 @@ fn addNewShip(options: AddTestOptions) -> Bool {
       },
       reference_script: None,
     }
+  let ship_address =
+    Address {
+      payment_credential: Script(shipyard_policy),
+      stake_credential: None,
+    }
+  let ship_datum =
+    ShipDatum {
+      pos_x: options.initial_x,
+      pos_y: options.initial_y,
+      ship_token_name: options.datum_ship_name,
+      pilot_token_name: options.datum_pilot_name,
+      last_move_latest_time: if options.uses_correct_latest_time {
+        options.latest_time
+      } else {
+        0
+      },
+    }
+  let ship_value =
+    from_lovelace(2_000_000)
+      |> add(shipyard_policy, options.ship_token_name, options.ship_tokens_paid)
+      |> add(mock.pellet_credential, "FUEL", options.fuel_paid)
+      |> add("aaaa", "tokenA", options.extra_token_amount)
+  let ship_out =
+    Output {
+      address: ship_address,
+      value: ship_value,
+      datum: InlineDatum(ship_datum),
+      reference_script: None,
+    }
   let tx =
     Transaction {
       inputs: [asteria_in],
       reference_inputs: [],
-      outputs: [asteria_out],
+      outputs: if options.includes_ship_output {
+        [asteria_out, ship_out]
+      } else {
+        [asteria_out]
+      },
       fee: 5_000,
-      mint: zero,
+      mint: from_asset(
+        shipyard_policy,
+        options.ship_token_name,
+        options.ship_token_minted_amount,
+      )
+        |> add(
+            shipyard_policy,
+            options.pilot_token_name,
+            options.pilot_token_minted_amount,
+          )
+        |> add(mock.pellet_credential, "FUEL", options.fuel_minted_amount),
       certificates: [],
       withdrawals: [],
       validity_range: Interval {
         lower_bound: IntervalBound { bound_type: Finite(1), is_inclusive: True },
         upper_bound: IntervalBound {
-          bound_type: Finite(10),
+          bound_type: Finite(10_000),
           is_inclusive: True,
         },
       },
@@ -128,7 +209,6 @@ fn addNewShip(options: AddTestOptions) -> Bool {
       treasury_donation: None,
     }
   let min_distance = 10
-  let initial_fuel = 480
   let result =
     asteria.asteria.spend(
       mock.pellet_credential,
@@ -136,7 +216,7 @@ fn addNewShip(options: AddTestOptions) -> Bool {
       ship_mint_lovelace_fee,
       max_asteria_mining,
       min_distance,
-      initial_fuel,
+      options.initial_fuel,
       Some(asteria_datum),
       redeemer,
       OutputReference { transaction_id: mock.transaction_id_1, output_index: 0 },
@@ -146,23 +226,119 @@ fn addNewShip(options: AddTestOptions) -> Bool {
 }
 
 test add_ok() {
-  addNewShip(default_add_options())
+  add_new_ship(default_add_options())
 }
 
 test no_fee_paid() fail {
-  addNewShip(AddTestOptions { ..default_add_options(), pay_fee: False })
+  add_new_ship(AddTestOptions { ..default_add_options(), pay_fee: False })
 }
 
 test no_admin_token() fail {
-  addNewShip(
+  add_new_ship(
     AddTestOptions { ..default_add_options(), include_admin_token: False },
   )
 }
 
 test counter_not_updated() fail {
-  addNewShip(AddTestOptions { ..default_add_options(), update_counter: False })
+  add_new_ship(AddTestOptions { ..default_add_options(), update_counter: False })
 }
 
 test shipyard_policy_not_preserved() fail {
-  addNewShip(AddTestOptions { ..default_add_options(), preserve_policy: False })
+  add_new_ship(AddTestOptions { ..default_add_options(), preserve_policy: False })
+}
+
+test ship_token_not_minted() fail {
+  add_new_ship(
+    AddTestOptions { ..default_add_options(), ship_token_minted_amount: 0 },
+  )
+}
+
+test ship_token_wrong_amount() fail {
+  add_new_ship(
+    AddTestOptions { ..default_add_options(), ship_token_minted_amount: 2 },
+  )
+}
+
+test pilot_token_not_minted() fail {
+  add_new_ship(
+    AddTestOptions { ..default_add_options(), pilot_token_minted_amount: 0 },
+  )
+}
+
+test pilot_token_wrong_amount() fail {
+  add_new_ship(
+    AddTestOptions { ..default_add_options(), pilot_token_minted_amount: 2 },
+  )
+}
+
+test fuel_tokens_not_minted() fail {
+  add_new_ship(AddTestOptions { ..default_add_options(), fuel_minted_amount: 0 })
+}
+
+test fuel_tokens_wrong_amount() fail {
+  add_new_ship(AddTestOptions { ..default_add_options(), fuel_minted_amount: 50 })
+}
+
+test wrong_ship_token_prefix() fail {
+  add_new_ship(
+    AddTestOptions { ..default_add_options(), ship_token_name: "SHI7" },
+  )
+}
+
+test wrong_ship_token_count() fail {
+  add_new_ship(
+    AddTestOptions { ..default_add_options(), ship_token_name: "SHP8" },
+  )
+}
+
+test wrong_pilot_token_prefix() fail {
+  add_new_ship(
+    AddTestOptions { ..default_add_options(), pilot_token_name: "PILO7" },
+  )
+}
+
+test wrong_pilot_token_count() fail {
+  add_new_ship(
+    AddTestOptions { ..default_add_options(), pilot_token_name: "PILOT8" },
+  )
+}
+
+test no_ship_output() fail {
+  add_new_ship(
+    AddTestOptions { ..default_add_options(), includes_ship_output: False },
+  )
+}
+
+test initial_distance_below_min() fail {
+  add_new_ship(
+    AddTestOptions { ..default_add_options(), initial_x: 3, initial_y: 3 },
+  )
+}
+
+test wrong_ship_name_in_datum() fail {
+  add_new_ship(AddTestOptions { ..default_add_options(), datum_ship_name: "FOO" })
+}
+
+test wrong_pilot_name_in_datum() fail {
+  add_new_ship(
+    AddTestOptions { ..default_add_options(), datum_pilot_name: "FOO" },
+  )
+}
+
+test wrong_latest_time_in_datum() fail {
+  add_new_ship(
+    AddTestOptions { ..default_add_options(), uses_correct_latest_time: False },
+  )
+}
+
+test ship_token_not_paid() fail {
+  add_new_ship(AddTestOptions { ..default_add_options(), ship_tokens_paid: 0 })
+}
+
+test wrong_initial_fuel() fail {
+  add_new_ship(AddTestOptions { ..default_add_options(), fuel_paid: 30 })
+}
+
+test add_extra_token() fail {
+  add_new_ship(AddTestOptions { ..default_add_options(), extra_token_amount: 1 })
 }

--- a/onchain/src/validators/tests/asteria/add_new_ship.ak
+++ b/onchain/src/validators/tests/asteria/add_new_ship.ak
@@ -71,7 +71,7 @@ fn add_new_ship(options: AddTestOptions) -> Bool {
   let shipyard_policy = mock.shipyard_policy
   let ship_mint_lovelace_fee = 2_000
   let max_asteria_mining = 40
-  let ship_counter = 7
+  let ship_counter = options.ship_counter
   let admin_token =
     AssetClass { policy: mock.admin_policy, name: mock.admin_token_name }
   let redeemer = AddNewShip

--- a/onchain/src/validators/tests/asteria/consume.ak
+++ b/onchain/src/validators/tests/asteria/consume.ak
@@ -126,11 +126,16 @@ fn consume(options: ConsumeTestOptions) -> Bool {
       current_treasury_amount: None,
       treasury_donation: None,
     }
+  let min_distance = 10
+  let initial_fuel = 480
   let result =
     asteria.asteria.spend(
+      mock.pellet_credential,
       admin_token,
       ship_mint_lovelace_fee,
       max_asteria_mining,
+      min_distance,
+      initial_fuel,
       Some(asteria_datum),
       redeemer,
       OutputReference { transaction_id: mock.transaction_id_1, output_index: 0 },

--- a/onchain/src/validators/tests/asteria/mine.ak
+++ b/onchain/src/validators/tests/asteria/mine.ak
@@ -138,11 +138,16 @@ fn mine(options: MineTestOptions) -> Bool {
       current_treasury_amount: None,
       treasury_donation: None,
     }
+  let min_distance = 10
+  let initial_fuel = 480
   let result =
     asteria.asteria.spend(
+      mock.pellet_credential,
       admin_token,
       ship_mint_lovelace_fee,
       max_asteria_mining,
+      min_distance,
+      initial_fuel,
       Some(asteria_datum),
       redeemer,
       OutputReference { transaction_id: mock.transaction_id_1, output_index: 0 },

--- a/onchain/src/validators/tests/shipyard/burn_ship.ak
+++ b/onchain/src/validators/tests/shipyard/burn_ship.ak
@@ -40,8 +40,6 @@ fn get_default_burn_options() -> BurnTestOptions {
 fn burn_ship(options: BurnTestOptions) -> Bool {
   let fuel_per_step = 1
   let max_ship_fuel = 100
-  let initial_fuel = 40
-  let min_distance = 10
   let ship_token_name = mock.ship_token_name
   let pilot_token_name = mock.pilot_token_name
   let shipyard_policy = mock.shipyard_policy
@@ -120,8 +118,6 @@ fn burn_ship(options: BurnTestOptions) -> Bool {
       max_speed,
       max_ship_fuel,
       fuel_per_step,
-      initial_fuel,
-      min_distance,
       redeemer,
       shipyard_policy,
       tx,

--- a/onchain/src/validators/tests/shipyard/mint_ship.ak
+++ b/onchain/src/validators/tests/shipyard/mint_ship.ak
@@ -21,7 +21,6 @@ type MintTestOptions {
   fuel_paid: Int,
   latest_time: Int,
   ship_counter: Int,
-  initial_fuel: Int,
   ship_tokens_paid: Int,
   extra_token_amount: Int,
   fuel_minted_amount: Int,
@@ -43,7 +42,6 @@ fn get_default_mint_options() {
     fuel_paid: 40,
     latest_time: 10_000,
     ship_counter: 7,
-    initial_fuel: 40,
     ship_tokens_paid: 1,
     extra_token_amount: 0,
     fuel_minted_amount: 40,
@@ -62,7 +60,6 @@ fn get_default_mint_options() {
 fn mint_ship(options: MintTestOptions) -> Bool {
   let fuel_per_step = 1
   let max_ship_fuel = 100
-  let min_distance = 10
   let shipyard_policy = mock.shipyard_policy
   let max_speed = Speed { distance: 1, time: 1_000 }
   let admin_token =
@@ -190,8 +187,6 @@ fn mint_ship(options: MintTestOptions) -> Bool {
       max_speed,
       max_ship_fuel,
       fuel_per_step,
-      options.initial_fuel,
-      min_distance,
       redeemer,
       shipyard_policy,
       tx,

--- a/onchain/src/validators/tests/shipyard/mint_ship.ak
+++ b/onchain/src/validators/tests/shipyard/mint_ship.ak
@@ -1,11 +1,13 @@
 use aiken/collection/dict
 use aiken/interval.{Finite, Interval, IntervalBound}
 use asteria/test_mock as mock
-use asteria/types.{AssetClass, AsteriaDatum, MintShip, ShipDatum, Speed}
+use asteria/types.{
+  AddNewShip, AssetClass, AsteriaDatum, MintShip, ShipDatum, Speed,
+}
 use cardano/address.{Address, Script}
 use cardano/assets.{AssetName, add, from_asset, from_lovelace}
 use cardano/transaction.{
-  InlineDatum, Input, Mint, Output, OutputReference, Transaction,
+  InlineDatum, Input, Mint, Output, OutputReference, Spend, Transaction,
 }
 use spacetime
 
@@ -165,6 +167,13 @@ fn mint_ship(options: MintTestOptions) -> Bool {
             redeemer_data
           },
         ),
+        Pair(
+          Spend(asteria_in.output_reference),
+          {
+            let redeemer_data: Data = AddNewShip
+            redeemer_data
+          },
+        ),
       ],
       datums: dict.empty,
       id: transaction_id,
@@ -200,129 +209,5 @@ test no_asteria_input() fail {
       ..get_default_mint_options(),
       includes_asteria_input: False,
     },
-  )
-}
-
-test ship_token_not_minted() fail {
-  mint_ship(
-    MintTestOptions {
-      ..get_default_mint_options(),
-      ship_token_minted_amount: 0,
-    },
-  )
-}
-
-test ship_token_wrong_amount() fail {
-  mint_ship(
-    MintTestOptions {
-      ..get_default_mint_options(),
-      ship_token_minted_amount: 2,
-    },
-  )
-}
-
-test pilot_token_not_minted() fail {
-  mint_ship(
-    MintTestOptions {
-      ..get_default_mint_options(),
-      pilot_token_minted_amount: 0,
-    },
-  )
-}
-
-test pilot_token_wrong_amount() fail {
-  mint_ship(
-    MintTestOptions {
-      ..get_default_mint_options(),
-      pilot_token_minted_amount: 2,
-    },
-  )
-}
-
-test fuel_tokens_not_minted() fail {
-  mint_ship(
-    MintTestOptions { ..get_default_mint_options(), fuel_minted_amount: 0 },
-  )
-}
-
-test fuel_tokens_wrong_amount() fail {
-  mint_ship(
-    MintTestOptions { ..get_default_mint_options(), fuel_minted_amount: 50 },
-  )
-}
-
-test wrong_ship_token_prefix() fail {
-  mint_ship(
-    MintTestOptions { ..get_default_mint_options(), ship_token_name: "SHI7" },
-  )
-}
-
-test wrong_ship_token_count() fail {
-  mint_ship(
-    MintTestOptions { ..get_default_mint_options(), ship_token_name: "SHP8" },
-  )
-}
-
-test wrong_pilot_token_prefix() fail {
-  mint_ship(
-    MintTestOptions { ..get_default_mint_options(), pilot_token_name: "PILO7" },
-  )
-}
-
-test wrong_pilot_token_count() fail {
-  mint_ship(
-    MintTestOptions { ..get_default_mint_options(), pilot_token_name: "PILOT8" },
-  )
-}
-
-test no_ship_output() fail {
-  mint_ship(
-    MintTestOptions {
-      ..get_default_mint_options(),
-      includes_ship_output: False,
-    },
-  )
-}
-
-test initial_distance_below_min() fail {
-  mint_ship(
-    MintTestOptions { ..get_default_mint_options(), initial_x: 3, initial_y: 3 },
-  )
-}
-
-test wrong_ship_name_in_datum() fail {
-  mint_ship(
-    MintTestOptions { ..get_default_mint_options(), datum_ship_name: "FOO" },
-  )
-}
-
-test wrong_pilot_name_in_datum() fail {
-  mint_ship(
-    MintTestOptions { ..get_default_mint_options(), datum_pilot_name: "FOO" },
-  )
-}
-
-test wrong_latest_time_in_datum() fail {
-  mint_ship(
-    MintTestOptions {
-      ..get_default_mint_options(),
-      uses_correct_latest_time: False,
-    },
-  )
-}
-
-test ship_token_not_paid() fail {
-  mint_ship(
-    MintTestOptions { ..get_default_mint_options(), ship_tokens_paid: 0 },
-  )
-}
-
-test wrong_initial_fuel() fail {
-  mint_ship(MintTestOptions { ..get_default_mint_options(), fuel_paid: 30 })
-}
-
-test add_extra_token() fail {
-  mint_ship(
-    MintTestOptions { ..get_default_mint_options(), extra_token_amount: 1 },
   )
 }

--- a/onchain/src/validators/tests/spacetime/gather.ak
+++ b/onchain/src/validators/tests/spacetime/gather.ak
@@ -56,8 +56,6 @@ fn gather(options: GatherTestOptions) -> Bool {
   let pellet_pos_y = 10
   let fuel_per_step = 1
   let max_ship_fuel = 100
-  let initial_pellet_fuel = 40
-  let min_asteria_distance = 10
   let max_speed = Speed { distance: 1, time: 1_000 }
   let earliest_time =
     if options.respects_latest_time {
@@ -270,8 +268,6 @@ fn gather(options: GatherTestOptions) -> Bool {
       max_speed,
       max_ship_fuel,
       fuel_per_step,
-      initial_pellet_fuel,
-      min_asteria_distance,
       Some(ship_input_datum),
       ship_redeemer,
       OutputReference { transaction_id: mock.transaction_id_1, output_index: 0 },

--- a/onchain/src/validators/tests/spacetime/mine_asteria.ak
+++ b/onchain/src/validators/tests/spacetime/mine_asteria.ak
@@ -45,9 +45,7 @@ fn mine(options: MineTestOptions) -> Bool {
   let min_ada = from_lovelace(2_000_000)
   let fuel_per_step = 1
   let max_ship_fuel = 100
-  let initial_fuel = 40
   let ship_fuel = 30
-  let min_distance = 10
   let max_speed = Speed { distance: 1, time: 1_000 }
   let earliest_time =
     if options.respects_latest_time {
@@ -220,8 +218,6 @@ fn mine(options: MineTestOptions) -> Bool {
       max_speed,
       max_ship_fuel,
       fuel_per_step,
-      initial_fuel,
-      min_distance,
       Some(ship_input_datum),
       redeemer,
       OutputReference { transaction_id: mock.transaction_id_1, output_index: 0 },

--- a/onchain/src/validators/tests/spacetime/move_ship.ak
+++ b/onchain/src/validators/tests/spacetime/move_ship.ak
@@ -61,8 +61,6 @@ fn move(options: MoveTestOptions) -> Bool {
   let fuel_per_step = 1
   let required_fuel = fuel_per_step * distance(options.delta_x, options.delta_y)
   let max_ship_fuel = 100
-  let initial_pellet_fuel = 40
-  let min_asteria_distance = 10
   let max_speed = Speed { distance: 1, time: 1_000 }
   let earliest_time =
     if options.respects_latest_time {
@@ -256,8 +254,6 @@ fn move(options: MoveTestOptions) -> Bool {
       max_speed,
       max_ship_fuel,
       fuel_per_step,
-      initial_pellet_fuel,
-      min_asteria_distance,
       Some(ship_input_datum),
       redeemer,
       OutputReference { transaction_id: mock.transaction_id_1, output_index: 0 },

--- a/onchain/src/validators/tests/spacetime/quit.ak
+++ b/onchain/src/validators/tests/spacetime/quit.ak
@@ -33,9 +33,7 @@ fn quit(options: QuitTestOptions) -> Bool {
   let min_ada = from_lovelace(2_000_000)
   let fuel_per_step = 1
   let max_ship_fuel = 100
-  let initial_fuel = 40
   let ship_fuel = 30
-  let min_distance = 10
   let max_speed = Speed { distance: 1, time: 1_000 }
   let admin_token =
     AssetClass { policy: mock.admin_policy, name: mock.admin_token_name }
@@ -176,8 +174,6 @@ fn quit(options: QuitTestOptions) -> Bool {
       max_speed,
       max_ship_fuel,
       fuel_per_step,
-      initial_fuel,
-      min_distance,
       Some(ship_input_datum),
       redeemer,
       OutputReference { transaction_id: mock.transaction_id_1, output_index: 0 },


### PR DESCRIPTION
Resolve AST-101 "FUEL tokens, FUEL tokens everywhere!" with the following changes:
- In fuel policy: check that minting can be done only in two cases:
  - when an admin token is provided from a wallet (for pellet creation)
  - when a valid Asteria is spend with redeemer AddNewShip
- In asteria/spend/AddNewShip: check that the ship UTxO is created and that all the minted initial fuel is paid to it.

Moreover, all validation logic is moved from the shipyard policy (spacetime/mint/MintShip) to asteria/spend/AddNewShip. Now, the shipyard policy only checks for the spending of a valid Asteria with redeemer AddNewShip. This is partially solving AST-302 "Crowded shipyard".

**Important**: This PR introduces changes to validator parameters, a breaking change for the off-chain code.
